### PR TITLE
GitHub Actions support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - created
+
+jobs:
+
+  build_mingw_toolchain:
+    name: MinGW-W64 Toolchain
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Environment Setup
+      run: |
+        sudo apt-get install bison bzip2 flex g++ gzip pax build-essential gcc 
+    - name: Compile Toolchain
+      run: |
+        chmod 755 *
+        ./mingw-w64-build --disable-gdb x86_64 ~/toolchains
+        ./mingw-w64-build x86_64.clean
+        ./mingw-w64-build pkgclean
+        cd /home/runner/toolchains/
+        rm -rf build-mingw-w64-x86_64.noindex
+        rm -rf source.noindex
+        rm -rf pkg
+        cd /home/runner
+        tar cvzf MinGW-w64.tar.gz toolchains/  
+    - name: Upload Release Asset
+      if: github.event_name == 'release'
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: /home/runner/MinGW-w64.tar.gz
+        asset_name: MinGW-w64.tar.gz
+        asset_content_type: application/gzip


### PR DESCRIPTION
1. Build the macOS toolchain 
  -- on commit
  -- on pull request
  -- on GitHub release creation
2. Support for uploading artefacts when a GitHub release is created. 

